### PR TITLE
Removed extra comma in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "body-parser": "^1.17.1",
     "bootstrap": "^3.3.7",
     "express": "^4.15.2",
-    "mongoose": "^4.9.5",
+    "mongoose": "^4.9.5"
   },
   "devDependencies": {
     "angular-mocks": "^1.6.4",


### PR DESCRIPTION
Package.json file had an extra common which caused an error message. It's been removed.