### PR TITLE
Fixed destination file path for images in the copy configuration

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function configureGrunt(gruntConfig) {
         files: [
           { cwd: 'client/src/',
             src: 'images/*.*',
-            dest: 'build/images/',
+            dest: 'build/',
             expand: true
           }
         ]


### PR DESCRIPTION
Small change to the copy configuration for images to be on the correct path in the build process.