### PR TITLE
Advance from login screen via getScene() works ok.  Still need more work on loadScene().

### DIFF
--- a/client/src/js/player.controller.js
+++ b/client/src/js/player.controller.js
@@ -4,13 +4,13 @@
   angular.module('adventure')
     .controller('PlayerController', PlayerController);
 
-  PlayerController.$inject = ['$state', 'PlayerService'];
+  PlayerController.$inject = ['$state', 'PlayerService', 'SceneService'];
 
   /**
    * Handles the player info
    * @return {void}
    */
-  function PlayerController($state, PlayerService) {
+  function PlayerController($state, PlayerService, SceneService) {
     let vm = this;
     vm.playerInfo = {};
     vm.hasError = false;
@@ -35,14 +35,14 @@
       }
       return PlayerService.loginPlayer(playerInfo)
         .then(function handleResponseData(responseData) {
-          $state.go('game');
+          console.log('responseData is', responseData);
+          SceneService.getScene(PlayerService.getEmail());
         })
         .catch(function handleErrors(errResponse) {
           vm.hasError = true;
         });
 
     };
-
   }
 
 }());

--- a/client/src/js/player.service.js
+++ b/client/src/js/player.service.js
@@ -42,8 +42,7 @@
         })
       })
       .then(function handleResponse(responseObj) {
-        console.log('Response object', responseObj.data);
-        playerEmail = responseObj.data.thePlayerAdded.playerEmail;
+        playerEmail = responseObj.data.thePlayerAdded[0].playerEmail;
         localStorage.setItem('email', playerEmail);
         return(responseObj.data);
       });

--- a/client/src/js/scene.controller.js
+++ b/client/src/js/scene.controller.js
@@ -6,50 +6,22 @@
     .controller('SceneController', SceneController);
 
   // inject the angular service that handles data calls for scene data
-  SceneController.$inject = ['$state', '$stateParams', 'SceneService'];
+  SceneController.$inject =
+    ['$state', '$stateParams', 'SceneService', 'PlayerService'];
 
   /**
    * SceneController creates a new scene Controller
    * @param {Object} SceneService Service singleton
    */
-  function SceneController($state, $stateParams, SceneService) {
+  function SceneController(
+    $state, $stateParams, SceneService, PlayerService) {
     let vm = this;
 
-    vm.playerEmail = '';  // store the current player's email
+    // store a copy of the SceneService.currentScene
+    vm.currentScene = SceneService.getCurrentScene();
 
-    vm.currentScene = {};  // store the scene to be displayed in the View
-
-    vm.toggle = true;      // used toggle a CSS class based on a click event
-
-    /**
-     * Function getScene() returns current scene data for a player
-     * @param  {String} inputEmail Player email address
-     * @return {void}
-     */
-    vm.getScene = function getScene(inputEmail) {
-      if (!inputEmail || inputEmail.length === 0 ||
-        typeof(inputEmail) !== 'string') {
-        console.info('Valid email required to get a scene');
-        return;
-      }
-
-      SceneService.getScene(inputEmail)
-        .then(function handleResponse(responseObj) {
-          vm.currentScene = responseObj;
-        })
-        .catch(function handleError(error) {
-          if (error.status === 401) {
-            vm.hasError = true;
-            vm.errorMessage = 'Scene not found';
-          } else if (error.status === 404) {
-            vm.hasError = true;
-            vm.errorMessage = 'Could not find that scene by the id provided';
-          } else {
-            vm.hasError = true;
-            vm.errorMessage = 'Unknown error from server';
-          }
-        });
-    };
+    // get the current player's email
+    vm.playerEmail = localStorage.getItem('email');
 
     /**
      * Function loadScene() will load the current scene, or the next scene
@@ -60,7 +32,6 @@
      * @return {Object}            Scene data
      */
     vm.loadScene = function loadScene(inputId, inputText, inputEmail) {
-      console.log('input variables to scene.router:', inputId, inputText, inputEmail);
       if (!inputId || inputId.length === 0 || typeof(inputId) !== 'string') {
         console.info('Valid id required to load a scene');
         return;
@@ -80,7 +51,8 @@
 
       SceneService.loadScene(inputId, inputText, inputEmail)
         .then(function handleResponse(responseObj) {
-          vm.currentScene = responseObj;
+          console.log('loadScene on controller responseObj is', responseObj);
+          vm.currentScene = responseObj.data;
         })
         .catch(function handleError(error) {
           if (error.status === 401) {
@@ -94,6 +66,26 @@
             vm.errorMessage = 'Unknown error from server';
           }
         });
+    };
+
+    /**
+     * Function getEmail() returns the player email
+     * @return {String} player email
+     */
+    vm.getEmail = function getEmail() {
+      let emailReturned = PlayerService.getEmail();
+      console.log('emailReturned is', emailReturned);
+      return emailReturned;
+    };
+
+    /**
+     * Function getCurrentScene() a) stores the currentScene Object
+     *                            b) returns scene text for current scene
+     * @return {String} Scene text from current scene
+     */
+    vm.getCurrentScene = function getCurrentScene() {
+      vm.currentScene = SceneService.getCurrentScene();
+      return vm.currentScene.sceneText;
     };
   }
 }());

--- a/client/src/js/scene.service.js
+++ b/client/src/js/scene.service.js
@@ -3,14 +3,24 @@
 
   angular.module('adventure')
     .factory('SceneService', SceneService);
-  SceneService.$inject = ['$http'];
+  SceneService.$inject = ['$http', '$state'];
 
   /**
    * Creates a new SceneService
    * @param {Function} $http Makes Ajax calls
    * @return {Object}        The service's API methods
    */
-  function SceneService($http) {
+  function SceneService($http, $state) {
+    let currentScene = {};
+
+    /**
+     * Function getCurrentScene() returns the current scene
+     * @return {Object} current scene Object
+     */
+    function getCurrentScene() {
+      return currentScene;
+    }
+
     /**
      * Function getScene() returns current scene for a player
      * @param  {String} inputEmail Player email
@@ -25,8 +35,9 @@
         }
       })
       .then(function handleResponse(responseObj) {
-        console.log('service responseObj is: ', responseObj);
-        return responseObj.data;
+        currentScene = responseObj.data;
+        console.log('SceneService wrote currentScene as', currentScene);
+        $state.go('game');
       });
     }
 
@@ -51,12 +62,13 @@
         })
       })
       .then(function handleResponse(responseObj) {
-        console.log('service responseObj is: ', responseObj);
-        return responseObj.data;
+        currentScene = responseObj.data;
+        return responseObj;
       });
     }
 
     return {
+      getCurrentScene: getCurrentScene,
       getScene: getScene,
       loadScene: loadScene
     };

--- a/client/src/views/game.template.html
+++ b/client/src/views/game.template.html
@@ -1,22 +1,12 @@
 <article>
   <p>{{sceneCtrl.currentScene.sceneText}}</p>
-  <p ng-class='{"choiceDisplay": sceneCtrl.toggle}'>Tap the icon below and select an option in the scene:</p>
-  <a
-    ng-click=
-      'sceneCtrl.toggle = !sceneCtrl.toggle;
-      sceneCtrl.getScene("")'
-
-    class='option_icon glyphicon glyphicon-menu-hamburger'>
-  </a>
 </article>
-
 
 <article
   class='sceneImage'
   ng-style='{ "background-image":
   "url(" + sceneCtrl.currentScene.sceneImage + ")" }'>
   <section
-    ng-class='{"choiceDisplay": sceneCtrl.toggle}'
     ng-repeat='sceneChoices in sceneCtrl.currentScene'>
     <p
       class='clickText'
@@ -24,9 +14,10 @@
       ng-click = 'sceneCtrl.loadScene(
         sceneCtrl.currentScene.id,
         sceneChoice.choiceText,
-        sceneCtrl.playerEmail)'>
+        sceneCtrl.getEmail())'>
       <a class = 'clickText' ng-class='sceneChoice.choiceIcon'></a>
       {{sceneChoice.choiceText}}
     </p>
   </section>
+  <p>{{sceneCtrl.currentScene}}</p>
 </article>

--- a/server/routes/player.routes.js
+++ b/server/routes/player.routes.js
@@ -26,12 +26,13 @@ function addAPlayer(request, response, next) {
   }
 
   Player.find({playerEmail: request.body.playerEmail})
-    .then(function checkIfPlayerIsPresent(email) {
-      if(email.length === 0) {
+    .then(function checkIfPlayerIsPresent(player) {
+      if(player.length === 0) {
         let thePlayerCreated = new Player({
           playerName: request.body.playerName,
           playerEmail: request.body.playerEmail,
-          playerScore: request.body.playerScore
+          playerScore: request.body.playerScore,
+          playerScene: '58ffe14978feb61989d68e03'
         });
         thePlayerCreated.save()
           .then(function sendBackTheResponse(data) {
@@ -45,6 +46,11 @@ function addAPlayer(request, response, next) {
           });
       } else {
         console.log('Player already exists');
+        // return the existing player
+        console.log('player exists and the object is:', player);
+        response.json(
+          { message: 'Sign-in matches existing player:',
+            thePlayerAdded: player });
       }
     })
     .catch(function handleErrors(err) {

--- a/server/routes/scene.routes.js
+++ b/server/routes/scene.routes.js
@@ -19,10 +19,6 @@ sceneRouter.get('/:inputEmail', function getScene(request, response, next) {
     return next(err);
   }
 
-  // last scene where we will return to the start page
-  let scoreSceneId;
-  let startSceneId;
-
   // data that will be updated while determining the next Scene
   let matchingScore;
   let thisScene;
@@ -98,7 +94,8 @@ sceneRouter.patch('/', function loadScene(request, response, next) {
   if (!request.body) {
     let err = new Error('You must provide scene and choice info');
     err.status = 400;
-    return next(err);
+    next(err);
+    return;
   }
 
   if (!request.body.inputId || request.body.inputId.length === 0 ||
@@ -126,8 +123,8 @@ sceneRouter.patch('/', function loadScene(request, response, next) {
   }
 
   // last scene where we will return to the start page
-  let endSceneId;
-  let startSceneId;
+  // NOTE: this will need to be manually populated Heroku via seed file
+  let endSceneId = '58ffe14978feb61989d68e0b';
 
   // data that will be updated while determining the next Scene
   let matchingScore;
@@ -147,7 +144,8 @@ sceneRouter.patch('/', function loadScene(request, response, next) {
         let err = new Error(
           'Cannot find scene that matches the player choice!');
         err.status = 404;
-        return next(err);
+        next(err);
+        return;
       }
       console.log('The scene matching inputText is', data);
 
@@ -188,6 +186,7 @@ sceneRouter.patch('/', function loadScene(request, response, next) {
           let ourError = new Error ('Unable to search for current Scene');
           ourError.status = 500;
           next(err);
+          return;
         });
 
       // update the playerScene and playerScore
@@ -218,6 +217,7 @@ sceneRouter.patch('/', function loadScene(request, response, next) {
             let ourError = new Error ('Unable to update player!');
             ourError.status = 500;
             next(err);
+            return;
           }
         });
 
@@ -228,6 +228,7 @@ sceneRouter.patch('/', function loadScene(request, response, next) {
         let ourError = new Error ('Unable to search for Scene');
         ourError.status = 500;
         next(err);
+        return;
       });
     })
     .catch(function handleIssues(err) {
@@ -235,6 +236,7 @@ sceneRouter.patch('/', function loadScene(request, response, next) {
         'Unable to search for Scene that matches the player choice!');
       ourError.status = 500;
       next(err);
+      return;
     });
 });
 


### PR DESCRIPTION
Player can log in and be moved to the first game scene via getScene().

Moving between scenes via loadScene() works if choices made with >2 seconds pause:
Player can cycle between scenes with loadScene() *only* if they choose their scene options "slowly"...that is, there is a 2 second or more pause between choices.  Otherwise, MongoDB returns an empty object and the scene has no data for Angular to populate into the scene view.

To test:  update line 127 of scene.routes.js (let endSceneId = '58ffe14978feb61989d68e0b';) with the _id of the last scene in your MongoDB scenes object list.  This variable is used to determine when to reset the player's score.  (that is, *if* we decide to reset the player's score at the end of the game).

To merge:  I would need to clear line 127 of the above string and make the value:  ""
